### PR TITLE
Include class' classloader in search for key file (no leading /)

### DIFF
--- a/src/main/java/com/synopsys/integration/encryption/EncryptionUtils.java
+++ b/src/main/java/com/synopsys/integration/encryption/EncryptionUtils.java
@@ -137,6 +137,12 @@ public class EncryptionUtils {
         // Note: The context ClassLoader cannot take paths starting with '/'; the path must be relative to the common resource directory (i.e. src/main/resources).
         Key key = retrieveKeyFromFile(keyFile, contextClassloader);
         if (key == null) {
+            key = retrieveKeyFromFile(keyFile, getClass().getClassLoader());
+        }
+        if (key == null) {
+            key = retrieveKeyFromFile("/" + keyFile, contextClassloader);
+        }
+        if (key == null) {
             key = retrieveKeyFromFile("/" + keyFile, getClass().getClassLoader());
         }
         return key;

--- a/src/main/java/com/synopsys/integration/encryption/EncryptionUtils.java
+++ b/src/main/java/com/synopsys/integration/encryption/EncryptionUtils.java
@@ -140,9 +140,6 @@ public class EncryptionUtils {
             key = retrieveKeyFromFile(keyFile, getClass().getClassLoader());
         }
         if (key == null) {
-            key = retrieveKeyFromFile("/" + keyFile, contextClassloader);
-        }
-        if (key == null) {
             key = retrieveKeyFromFile("/" + keyFile, getClass().getClassLoader());
         }
         return key;


### PR DESCRIPTION
This change seems to get pass the key=null error in coverity jenkins