### PR TITLE
Sb excluded included filter list ctors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,6 @@ language: java
 sudo: false
 install: true
 
-addons:
-  sonarcloud:
-    token:
-      secure: "WHrFg7mTEDzBc0lFVWxD9618bVpU8pDDsMTP/lLJnmPpboEDdcNNtcTF31glrL3Cn1Sc207QmK8Kwo5bQf7B+kAyroYrlymPR8CDHJMBabQOBlxtXKEeuKMjZ1dsQjvjwGNYRmEB8qmcO3n38VtKyCnsPK3o0fMo1YIJbVNinydQtLFAcneyP/q+i5pyOTtOs+UARDOpuqHx/5YEq+O3zbq7wyphgcQEfeo8KyRqvGU47FJBU23wNLwheq+rQNpMvddPnV0pvy3UMCl40y3SDBbmofq/tqL9xjfesELMXhZxsaysGFRMQSFfLVg16hQvHDdInWpC6HTpfqUSOW0rSOURicjVvRpsdRJyGSTmvePCJKkn8wD2Kfi6yoFiASos5JWziBYX4LvaUQY59ukFJtWuFrHQp9O4re1AMrLfYBRq5eclNbZegmPKQd2XtEmfga/1csTdOPVYAq7eoRWvxV3JFO9VzFhBR6n1m0+1fKNEHWWEWKCaKCYK1asd68sK73D+QA8sUtI+zrKt2XB/OFo07apTiPBpLTdx8T+PZTo23pW8t0IBTBGw+aJn2YzNr7ocUgAcTxlhKhiwx2v38vh3qYa1hWTbe6DnzDpSgjUngk7KJZi7t0UeV5fJNWMpgxDW4YOmM6RKqeQRaxuQjrEX2C4gPLA/cPbL+3Bj1Hc="
-
 jdk:
 - openjdk8
 
@@ -20,7 +15,7 @@ notifications:
     - starlabs@synopsys.com
 
 script:
-- "./gradlew clean build jacocoTestReport coveralls sonarqube"
+- "./gradlew clean build"
 
 env:
 - DETECT_GRADLE_INCLUDED_CONFIGURATIONS=compile
@@ -31,6 +26,5 @@ after_success:
 cache:
   directories:
   - "$HOME/.m2/repository"
-  - "$HOME/.sonar/cache"
   - "$HOME/.gradle"
   - ".gradle"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The integration-common library supplies shared utilities across many integration
 [![Coverage Status](https://coveralls.io/repos/github/blackducksoftware/integration-common/badge.svg?branch=master)](https://coveralls.io/github/blackducksoftware/integration-common?branch=master) 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) 
 [![Black Duck Security Risk](https://copilot.blackducksoftware.com/github/repos/blackducksoftware/integration-common/branches/master/badge-risk.svg)](https://copilot.blackducksoftware.com/github/repos/blackducksoftware/integration-common/branches/master)
-[![Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=com.blackducksoftware.integration%3Aintegration-common&metric=alert_status)](https://sonarcloud.io/dashboard?id=com.synopsys.integration%3Aintegration-common)
+[![Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=com.synopsys.integration%3Aintegration-common&metric=alert_status)](https://sonarcloud.io/dashboard?id=com.synopsys.integration%3Aintegration-common)
 
 ## Where can I get the latest release? ##
 You can download the latest release from Maven Central.

--- a/src/main/java/com/synopsys/integration/util/ExcludedIncludedFilter.java
+++ b/src/main/java/com/synopsys/integration/util/ExcludedIncludedFilter.java
@@ -35,9 +35,13 @@ public class ExcludedIncludedFilter {
     protected final Set<String> excludedSet;
     protected final Set<String> includedSet;
 
+    /**
+     * Construct a filter with no excludes (and no includes).
+     */
     public ExcludedIncludedFilter() {
         this(Collections.emptyList(), Collections.emptyList());
     }
+
     /**
      * Provide a comma-separated list of names to exclude and/or a comma-separated list of names to include. Exclusion rules always win.
      */
@@ -45,11 +49,14 @@ public class ExcludedIncludedFilter {
         excludedSet = createSetFromString(toExclude);
         includedSet = createSetFromString(toInclude);
     }
+
+    /**
+     * Provide a list of names to exclude and/or a list of names to include. Exclusion rules always win.
+     */
     public ExcludedIncludedFilter(List<String> toExcludeList, List<String> toIncludeList) {
         excludedSet = createSetFromList(toExcludeList);
         includedSet = createSetFromList(toIncludeList);
     }
-
 
     public boolean willExclude(String itemName) {
         if (excludedSet.contains(itemName)) {
@@ -81,8 +88,9 @@ public class ExcludedIncludedFilter {
         }
         return set;
     }
+
     private Set<String> createSetFromList(List<String> list) {
-        final Set<String> set = new HashSet<>();
+        Set<String> set = new HashSet<>();
         CollectionUtils.addAll(set, list);
         return set;
     }

--- a/src/main/java/com/synopsys/integration/util/ExcludedIncludedFilter.java
+++ b/src/main/java/com/synopsys/integration/util/ExcludedIncludedFilter.java
@@ -22,17 +22,23 @@
  */
 package com.synopsys.integration.util;
 
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.regex.Pattern;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 
 public class ExcludedIncludedFilter {
     protected final Set<String> excludedSet;
     protected final Set<String> includedSet;
 
+    public ExcludedIncludedFilter() {
+        this(Collections.emptyList(), Collections.emptyList());
+    }
     /**
      * Provide a comma-separated list of names to exclude and/or a comma-separated list of names to include. Exclusion rules always win.
      */
@@ -40,6 +46,11 @@ public class ExcludedIncludedFilter {
         excludedSet = createSetFromString(toExclude);
         includedSet = createSetFromString(toInclude);
     }
+    public ExcludedIncludedFilter(List<String> toExcludeList, List<String> toIncludeList) {
+        excludedSet = createSetFromList(toExcludeList);
+        includedSet = createSetFromList(toIncludeList);
+    }
+
 
     public boolean willExclude(final String itemName) {
         if (excludedSet.contains(itemName)) {
@@ -71,5 +82,9 @@ public class ExcludedIncludedFilter {
         }
         return set;
     }
-
+    private Set<String> createSetFromList(List<String> list) {
+        final Set<String> set = new HashSet<>();
+        CollectionUtils.addAll(set, list);
+        return set;
+    }
 }

--- a/src/main/java/com/synopsys/integration/util/ExcludedIncludedFilter.java
+++ b/src/main/java/com/synopsys/integration/util/ExcludedIncludedFilter.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.StringTokenizer;
 
-import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 
 public class ExcludedIncludedFilter {
@@ -54,8 +53,8 @@ public class ExcludedIncludedFilter {
      * Provide a list of names to exclude and/or a list of names to include. Exclusion rules always win.
      */
     public ExcludedIncludedFilter(List<String> toExcludeList, List<String> toIncludeList) {
-        excludedSet = createSetFromList(toExcludeList);
-        includedSet = createSetFromList(toIncludeList);
+        excludedSet = new HashSet<>(toExcludeList);
+        includedSet = new HashSet<>(toIncludeList);
     }
 
     public boolean willExclude(String itemName) {
@@ -89,9 +88,4 @@ public class ExcludedIncludedFilter {
         return set;
     }
 
-    private Set<String> createSetFromList(List<String> list) {
-        Set<String> set = new HashSet<>();
-        CollectionUtils.addAll(set, list);
-        return set;
-    }
 }

--- a/src/main/java/com/synopsys/integration/util/ExcludedIncludedWildcardFilter.java
+++ b/src/main/java/com/synopsys/integration/util/ExcludedIncludedWildcardFilter.java
@@ -22,6 +22,7 @@
  */
 package com.synopsys.integration.util;
 
+import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
 
@@ -31,8 +32,15 @@ import org.apache.commons.io.FilenameUtils;
  * Uses '*' and '?' characters for matching, as defined here: <a href="https://commons.apache.org/proper/commons-io/javadocs/api-2.5/org/apache/commons/io/FilenameUtils.html#wildcardMatch(java.lang.String,%20java.lang.String)">FilenameUtils.wildcardMatch</a>
  */
 public class ExcludedIncludedWildcardFilter extends ExcludedIncludedFilter {
+    public ExcludedIncludedWildcardFilter() {
+        super();
+    }
+
     public ExcludedIncludedWildcardFilter(final String toExclude, final String toInclude) {
         super(toExclude, toInclude);
+    }
+    public ExcludedIncludedWildcardFilter(List<String> toExcludeList, List<String> toIncludeList) {
+        super(toExcludeList, toIncludeList);
     }
 
     @Override

--- a/src/main/java/com/synopsys/integration/util/ExcludedIncludedWildcardFilter.java
+++ b/src/main/java/com/synopsys/integration/util/ExcludedIncludedWildcardFilter.java
@@ -32,7 +32,7 @@ import org.apache.commons.io.FilenameUtils;
  * Uses '*' and '?' characters for matching, as defined here: <a href="https://commons.apache.org/proper/commons-io/javadocs/api-2.5/org/apache/commons/io/FilenameUtils.html#wildcardMatch(java.lang.String,%20java.lang.String)">FilenameUtils.wildcardMatch</a>
  */
 public class ExcludedIncludedWildcardFilter extends ExcludedIncludedFilter {
-
+    
     public ExcludedIncludedWildcardFilter() {
         super();
     }

--- a/src/test/java/com/synopsys/integration/util/ExcludedIncludedFilterTest.java
+++ b/src/test/java/com/synopsys/integration/util/ExcludedIncludedFilterTest.java
@@ -13,10 +13,10 @@ public class ExcludedIncludedFilterTest {
         excludedIncludedFilter = new ExcludedIncludedFilter("", "");
         assertTrue(excludedIncludedFilter.shouldInclude("whatever"));
 
-        excludedIncludedFilter = new ExcludedIncludedFilter(null, null);
+        excludedIncludedFilter = new ExcludedIncludedFilter();
         assertTrue(excludedIncludedFilter.shouldInclude("whatever"));
 
-        excludedIncludedFilter = new ExcludedIncludedFilter(null, null);
+        excludedIncludedFilter = new ExcludedIncludedFilter();
         assertTrue(excludedIncludedFilter.shouldInclude("whatever"));
     }
 

--- a/src/test/java/com/synopsys/integration/util/ExcludedIncludedWildcardFilterTest.java
+++ b/src/test/java/com/synopsys/integration/util/ExcludedIncludedWildcardFilterTest.java
@@ -3,6 +3,9 @@ package com.synopsys.integration.util;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.junit.Ignore;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -38,6 +41,32 @@ public class ExcludedIncludedWildcardFilterTest {
         assertTrue(excludedIncludedFilter.shouldInclude("bad*"));
         assertFalse(excludedIncludedFilter.shouldInclude("bad\\"));
         assertFalse(excludedIncludedFilter.shouldInclude("bad\\Monkey"));
+    }
+
+    @Test
+    public void testIncludedAndExcludedList() {
+        List<String> toExclude = Arrays.asList("redherring", "*bad*");
+        List<String> toInclude = Arrays.asList("good*", "bad");
+        ExcludedIncludedFilter excludedIncludedFilter = new ExcludedIncludedWildcardFilter(toExclude, toInclude);
+        assertFalse(excludedIncludedFilter.shouldInclude("whatever"));
+        assertTrue(excludedIncludedFilter.shouldInclude("good"));
+        assertTrue(excludedIncludedFilter.shouldInclude("goodMonkey"));
+        assertFalse(excludedIncludedFilter.shouldInclude("bad"));
+        assertFalse(excludedIncludedFilter.shouldInclude("goodbad"));
+        assertFalse(excludedIncludedFilter.shouldInclude("really_bad"));
+        assertFalse(excludedIncludedFilter.shouldInclude("also_really_bad"));
+    }
+
+    @Test
+    public void testNothingIncludedOrExcluded() {
+        ExcludedIncludedFilter excludedIncludedFilter = new ExcludedIncludedWildcardFilter();
+        assertTrue(excludedIncludedFilter.shouldInclude("whatever"));
+        assertTrue(excludedIncludedFilter.shouldInclude("good"));
+        assertTrue(excludedIncludedFilter.shouldInclude("goodMonkey"));
+        assertTrue(excludedIncludedFilter.shouldInclude("bad"));
+        assertTrue(excludedIncludedFilter.shouldInclude("goodbad"));
+        assertTrue(excludedIncludedFilter.shouldInclude("really_bad"));
+        assertTrue(excludedIncludedFilter.shouldInclude("also_really_bad"));
     }
 
 }


### PR DESCRIPTION
Adding these new list-based constructors would simplify some code in Detect. Currently Detect has lists, and must convert them to comma-separated Strings to accommodate the existing filter constructors (which then split them apart again).

One caveat: If existing client code calls the constructors with (null, null), that code will no longer compile, as that is now ambiguous. I added default constructors for that case, but it's a breaking change for that code.