### PR TITLE
update regex for more languages

### DIFF
--- a/src/main/java/com/synopsys/integration/builder/Buildable.java
+++ b/src/main/java/com/synopsys/integration/builder/Buildable.java
@@ -1,7 +1,7 @@
 /*
  * integration-common
  *
- * Copyright (c) 2022 Synopsys, Inc.
+ * Copyright (c) 2023 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/builder/BuilderProperties.java
+++ b/src/main/java/com/synopsys/integration/builder/BuilderProperties.java
@@ -1,7 +1,7 @@
 /*
  * integration-common
  *
- * Copyright (c) 2022 Synopsys, Inc.
+ * Copyright (c) 2023 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/builder/BuilderPropertyKey.java
+++ b/src/main/java/com/synopsys/integration/builder/BuilderPropertyKey.java
@@ -1,7 +1,7 @@
 /*
  * integration-common
  *
- * Copyright (c) 2022 Synopsys, Inc.
+ * Copyright (c) 2023 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/builder/BuilderStatus.java
+++ b/src/main/java/com/synopsys/integration/builder/BuilderStatus.java
@@ -1,7 +1,7 @@
 /*
  * integration-common
  *
- * Copyright (c) 2022 Synopsys, Inc.
+ * Copyright (c) 2023 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/builder/IntegrationBuilder.java
+++ b/src/main/java/com/synopsys/integration/builder/IntegrationBuilder.java
@@ -1,7 +1,7 @@
 /*
  * integration-common
  *
- * Copyright (c) 2022 Synopsys, Inc.
+ * Copyright (c) 2023 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/datastructure/SetMap.java
+++ b/src/main/java/com/synopsys/integration/datastructure/SetMap.java
@@ -1,7 +1,7 @@
 /*
  * integration-common
  *
- * Copyright (c) 2022 Synopsys, Inc.
+ * Copyright (c) 2023 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/exception/IntegrationArgumentException.java
+++ b/src/main/java/com/synopsys/integration/exception/IntegrationArgumentException.java
@@ -1,7 +1,7 @@
 /*
  * integration-common
  *
- * Copyright (c) 2022 Synopsys, Inc.
+ * Copyright (c) 2023 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/exception/IntegrationException.java
+++ b/src/main/java/com/synopsys/integration/exception/IntegrationException.java
@@ -1,7 +1,7 @@
 /*
  * integration-common
  *
- * Copyright (c) 2022 Synopsys, Inc.
+ * Copyright (c) 2023 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/exception/IntegrationTimeoutException.java
+++ b/src/main/java/com/synopsys/integration/exception/IntegrationTimeoutException.java
@@ -1,7 +1,7 @@
 /*
  * integration-common
  *
- * Copyright (c) 2022 Synopsys, Inc.
+ * Copyright (c) 2023 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/executable/DryRunExecutableRunner.java
+++ b/src/main/java/com/synopsys/integration/executable/DryRunExecutableRunner.java
@@ -1,7 +1,7 @@
 /*
  * integration-common
  *
- * Copyright (c) 2022 Synopsys, Inc.
+ * Copyright (c) 2023 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/executable/Executable.java
+++ b/src/main/java/com/synopsys/integration/executable/Executable.java
@@ -1,7 +1,7 @@
 /*
  * integration-common
  *
- * Copyright (c) 2022 Synopsys, Inc.
+ * Copyright (c) 2023 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/executable/ExecutableOutput.java
+++ b/src/main/java/com/synopsys/integration/executable/ExecutableOutput.java
@@ -1,7 +1,7 @@
 /*
  * integration-common
  *
- * Copyright (c) 2022 Synopsys, Inc.
+ * Copyright (c) 2023 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/executable/ExecutableRunner.java
+++ b/src/main/java/com/synopsys/integration/executable/ExecutableRunner.java
@@ -1,7 +1,7 @@
 /*
  * integration-common
  *
- * Copyright (c) 2022 Synopsys, Inc.
+ * Copyright (c) 2023 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/executable/ExecutableRunnerException.java
+++ b/src/main/java/com/synopsys/integration/executable/ExecutableRunnerException.java
@@ -1,7 +1,7 @@
 /*
  * integration-common
  *
- * Copyright (c) 2022 Synopsys, Inc.
+ * Copyright (c) 2023 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/executable/ExecutableStreamThread.java
+++ b/src/main/java/com/synopsys/integration/executable/ExecutableStreamThread.java
@@ -1,7 +1,7 @@
 /*
  * integration-common
  *
- * Copyright (c) 2022 Synopsys, Inc.
+ * Copyright (c) 2023 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/executable/ProcessBuilderRunner.java
+++ b/src/main/java/com/synopsys/integration/executable/ProcessBuilderRunner.java
@@ -1,7 +1,7 @@
 /*
  * integration-common
  *
- * Copyright (c) 2022 Synopsys, Inc.
+ * Copyright (c) 2023 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/function/ThrowingBiFunction.java
+++ b/src/main/java/com/synopsys/integration/function/ThrowingBiFunction.java
@@ -1,7 +1,7 @@
 /*
  * integration-common
  *
- * Copyright (c) 2022 Synopsys, Inc.
+ * Copyright (c) 2023 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/function/ThrowingConsumer.java
+++ b/src/main/java/com/synopsys/integration/function/ThrowingConsumer.java
@@ -1,7 +1,7 @@
 /*
  * integration-common
  *
- * Copyright (c) 2022 Synopsys, Inc.
+ * Copyright (c) 2023 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/function/ThrowingFunction.java
+++ b/src/main/java/com/synopsys/integration/function/ThrowingFunction.java
@@ -1,7 +1,7 @@
 /*
  * integration-common
  *
- * Copyright (c) 2022 Synopsys, Inc.
+ * Copyright (c) 2023 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/function/ThrowingSupplier.java
+++ b/src/main/java/com/synopsys/integration/function/ThrowingSupplier.java
@@ -1,7 +1,7 @@
 /*
  * integration-common
  *
- * Copyright (c) 2022 Synopsys, Inc.
+ * Copyright (c) 2023 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/log/BufferedIntLogger.java
+++ b/src/main/java/com/synopsys/integration/log/BufferedIntLogger.java
@@ -1,7 +1,7 @@
 /*
  * integration-common
  *
- * Copyright (c) 2022 Synopsys, Inc.
+ * Copyright (c) 2023 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/log/IntLogger.java
+++ b/src/main/java/com/synopsys/integration/log/IntLogger.java
@@ -1,7 +1,7 @@
 /*
  * integration-common
  *
- * Copyright (c) 2022 Synopsys, Inc.
+ * Copyright (c) 2023 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/log/LogLevel.java
+++ b/src/main/java/com/synopsys/integration/log/LogLevel.java
@@ -1,7 +1,7 @@
 /*
  * integration-common
  *
- * Copyright (c) 2022 Synopsys, Inc.
+ * Copyright (c) 2023 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/log/PrintStreamIntLogger.java
+++ b/src/main/java/com/synopsys/integration/log/PrintStreamIntLogger.java
@@ -1,7 +1,7 @@
 /*
  * integration-common
  *
- * Copyright (c) 2022 Synopsys, Inc.
+ * Copyright (c) 2023 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/log/SilentIntLogger.java
+++ b/src/main/java/com/synopsys/integration/log/SilentIntLogger.java
@@ -1,7 +1,7 @@
 /*
  * integration-common
  *
- * Copyright (c) 2022 Synopsys, Inc.
+ * Copyright (c) 2023 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/log/Slf4jIntLogger.java
+++ b/src/main/java/com/synopsys/integration/log/Slf4jIntLogger.java
@@ -1,7 +1,7 @@
 /*
  * integration-common
  *
- * Copyright (c) 2022 Synopsys, Inc.
+ * Copyright (c) 2023 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/log/Slf4jPrefixIntLogger.java
+++ b/src/main/java/com/synopsys/integration/log/Slf4jPrefixIntLogger.java
@@ -1,7 +1,7 @@
 /*
  * integration-common
  *
- * Copyright (c) 2022 Synopsys, Inc.
+ * Copyright (c) 2023 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/util/CleanupZipExpander.java
+++ b/src/main/java/com/synopsys/integration/util/CleanupZipExpander.java
@@ -1,7 +1,7 @@
 /*
  * integration-common
  *
- * Copyright (c) 2022 Synopsys, Inc.
+ * Copyright (c) 2023 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/util/CommonZipExpander.java
+++ b/src/main/java/com/synopsys/integration/util/CommonZipExpander.java
@@ -1,7 +1,7 @@
 /*
  * integration-common
  *
- * Copyright (c) 2022 Synopsys, Inc.
+ * Copyright (c) 2023 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/util/EnumSetFactory.java
+++ b/src/main/java/com/synopsys/integration/util/EnumSetFactory.java
@@ -1,7 +1,7 @@
 /*
  * integration-common
  *
- * Copyright (c) 2022 Synopsys, Inc.
+ * Copyright (c) 2023 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/util/EnumUtils.java
+++ b/src/main/java/com/synopsys/integration/util/EnumUtils.java
@@ -1,7 +1,7 @@
 /*
  * integration-common
  *
- * Copyright (c) 2022 Synopsys, Inc.
+ * Copyright (c) 2023 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/util/ExcludedIncludedAllNoneFilter.java
+++ b/src/main/java/com/synopsys/integration/util/ExcludedIncludedAllNoneFilter.java
@@ -1,7 +1,7 @@
 /*
  * integration-common
  *
- * Copyright (c) 2022 Synopsys, Inc.
+ * Copyright (c) 2023 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/util/ExcludedIncludedFilter.java
+++ b/src/main/java/com/synopsys/integration/util/ExcludedIncludedFilter.java
@@ -1,7 +1,7 @@
 /*
  * integration-common
  *
- * Copyright (c) 2022 Synopsys, Inc.
+ * Copyright (c) 2023 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/util/ExcludedIncludedWildcardFilter.java
+++ b/src/main/java/com/synopsys/integration/util/ExcludedIncludedWildcardFilter.java
@@ -1,7 +1,7 @@
 /*
  * integration-common
  *
- * Copyright (c) 2022 Synopsys, Inc.
+ * Copyright (c) 2023 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/util/HostNameHelper.java
+++ b/src/main/java/com/synopsys/integration/util/HostNameHelper.java
@@ -1,7 +1,7 @@
 /*
  * integration-common
  *
- * Copyright (c) 2022 Synopsys, Inc.
+ * Copyright (c) 2023 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/util/IntEnvironmentVariables.java
+++ b/src/main/java/com/synopsys/integration/util/IntEnvironmentVariables.java
@@ -1,7 +1,7 @@
 /*
  * integration-common
  *
- * Copyright (c) 2022 Synopsys, Inc.
+ * Copyright (c) 2023 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/util/IntegrationEscapeUtil.java
+++ b/src/main/java/com/synopsys/integration/util/IntegrationEscapeUtil.java
@@ -1,7 +1,7 @@
 /*
  * integration-common
  *
- * Copyright (c) 2022 Synopsys, Inc.
+ * Copyright (c) 2023 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */
@@ -36,8 +36,7 @@ public class IntegrationEscapeUtil {
             return null;
         }
 
-        final String escaped = s.replaceAll("[^A-Za-z0-9]", "_");
-        return escaped;
+        return s.replaceAll("[^\\p{IsAlphabetic}\\p{Digit}]", "_");
     }
 
 }

--- a/src/main/java/com/synopsys/integration/util/IntegrationEscapeUtil.java
+++ b/src/main/java/com/synopsys/integration/util/IntegrationEscapeUtil.java
@@ -36,6 +36,8 @@ public class IntegrationEscapeUtil {
             return null;
         }
 
+        // Replace anything that is not an alphabetic character or a digit with an underscore.
+        // See https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html for further details.
         return s.replaceAll("[^\\p{IsAlphabetic}\\p{Digit}]", "_");
     }
 

--- a/src/main/java/com/synopsys/integration/util/MaskedStringFieldToStringBuilder.java
+++ b/src/main/java/com/synopsys/integration/util/MaskedStringFieldToStringBuilder.java
@@ -1,7 +1,7 @@
 /*
  * integration-common
  *
- * Copyright (c) 2022 Synopsys, Inc.
+ * Copyright (c) 2023 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/util/NameVersion.java
+++ b/src/main/java/com/synopsys/integration/util/NameVersion.java
@@ -1,7 +1,7 @@
 /*
  * integration-common
  *
- * Copyright (c) 2022 Synopsys, Inc.
+ * Copyright (c) 2023 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/util/NoThreadExecutorService.java
+++ b/src/main/java/com/synopsys/integration/util/NoThreadExecutorService.java
@@ -1,7 +1,7 @@
 /*
  * integration-common
  *
- * Copyright (c) 2022 Synopsys, Inc.
+ * Copyright (c) 2023 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/util/OperatingSystemType.java
+++ b/src/main/java/com/synopsys/integration/util/OperatingSystemType.java
@@ -1,7 +1,7 @@
 /*
  * integration-common
  *
- * Copyright (c) 2022 Synopsys, Inc.
+ * Copyright (c) 2023 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/util/ResourceUtil.java
+++ b/src/main/java/com/synopsys/integration/util/ResourceUtil.java
@@ -1,7 +1,7 @@
 /*
  * integration-common
  *
- * Copyright (c) 2022 Synopsys, Inc.
+ * Copyright (c) 2023 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/util/Stringable.java
+++ b/src/main/java/com/synopsys/integration/util/Stringable.java
@@ -1,7 +1,7 @@
 /*
  * integration-common
  *
- * Copyright (c) 2022 Synopsys, Inc.
+ * Copyright (c) 2023 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/util/TokenizerUtils.java
+++ b/src/main/java/com/synopsys/integration/util/TokenizerUtils.java
@@ -1,7 +1,7 @@
 /*
  * integration-common
  *
- * Copyright (c) 2022 Synopsys, Inc.
+ * Copyright (c) 2023 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/wait/ResilientJob.java
+++ b/src/main/java/com/synopsys/integration/wait/ResilientJob.java
@@ -1,7 +1,7 @@
 /*
  * integration-common
  *
- * Copyright (c) 2022 Synopsys, Inc.
+ * Copyright (c) 2023 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/wait/ResilientJobConfig.java
+++ b/src/main/java/com/synopsys/integration/wait/ResilientJobConfig.java
@@ -1,7 +1,7 @@
 /*
  * integration-common
  *
- * Copyright (c) 2022 Synopsys, Inc.
+ * Copyright (c) 2023 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/wait/ResilientJobExecutor.java
+++ b/src/main/java/com/synopsys/integration/wait/ResilientJobExecutor.java
@@ -1,7 +1,7 @@
 /*
  * integration-common
  *
- * Copyright (c) 2022 Synopsys, Inc.
+ * Copyright (c) 2023 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/wait/WaitJob.java
+++ b/src/main/java/com/synopsys/integration/wait/WaitJob.java
@@ -1,7 +1,7 @@
 /*
  * integration-common
  *
- * Copyright (c) 2022 Synopsys, Inc.
+ * Copyright (c) 2023 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/wait/WaitJobCondition.java
+++ b/src/main/java/com/synopsys/integration/wait/WaitJobCondition.java
@@ -1,7 +1,7 @@
 /*
  * integration-common
  *
- * Copyright (c) 2022 Synopsys, Inc.
+ * Copyright (c) 2023 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/wait/tracker/WaitIntervalTracker.java
+++ b/src/main/java/com/synopsys/integration/wait/tracker/WaitIntervalTracker.java
@@ -1,7 +1,7 @@
 /*
  * integration-common
  *
- * Copyright (c) 2022 Synopsys, Inc.
+ * Copyright (c) 2023 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/wait/tracker/WaitIntervalTrackerConstant.java
+++ b/src/main/java/com/synopsys/integration/wait/tracker/WaitIntervalTrackerConstant.java
@@ -1,7 +1,7 @@
 /*
  * integration-common
  *
- * Copyright (c) 2022 Synopsys, Inc.
+ * Copyright (c) 2023 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/wait/tracker/WaitIntervalTrackerFactory.java
+++ b/src/main/java/com/synopsys/integration/wait/tracker/WaitIntervalTrackerFactory.java
@@ -1,7 +1,7 @@
 /*
  * integration-common
  *
- * Copyright (c) 2022 Synopsys, Inc.
+ * Copyright (c) 2023 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/java/com/synopsys/integration/wait/tracker/WaitIntervalTrackerProgressive.java
+++ b/src/main/java/com/synopsys/integration/wait/tracker/WaitIntervalTrackerProgressive.java
@@ -1,7 +1,7 @@
 /*
  * integration-common
  *
- * Copyright (c) 2022 Synopsys, Inc.
+ * Copyright (c) 2023 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/test/java/com/synopsys/integration/util/IntegrationEscapeUtilTest.java
+++ b/src/test/java/com/synopsys/integration/util/IntegrationEscapeUtilTest.java
@@ -19,4 +19,14 @@ public class IntegrationEscapeUtilTest {
         final List<String> cleanStrings = Arrays.asList(new String[] { "_A_B_C___", "def", "__gh1__23_i__" });
         assertEquals(cleanStrings, integrationEscapeUtil.replaceWithUnderscore(messyStrings));
     }
+    
+    @Test
+    public void testNonEnglishEscaping() {
+    	IntegrationEscapeUtil integrationEscapeUtil = new IntegrationEscapeUtil();
+    	
+    	List<String> beforeEscaping = Arrays.asList(new String[] { "Black@^%&%(du*&)&ck123ブラックダック黑鸭子" });
+    	List<String> afterEscaping = Arrays.asList(new String[] { "Black______du____ck123ブラックダック黑鸭子" });
+    
+    	assertEquals(afterEscaping, integrationEscapeUtil.replaceWithUnderscore(beforeEscaping));
+    }
 }


### PR DESCRIPTION
There is a regex that hunts for digits and English characters and replaces anything other than those things with underscores. This approach works fine for English itself but it confuses multibyte non-English characters as non-characters and erroneously replaces them with underscores. 

This work leverages Java 8 functionality, see https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html for details, to recognize characters independent of language.

Note: the build decided to update all copyrights so I'm sourcing those files but there are only really 2 files with actual changes.