### PR TITLE
HUB-42458 - Add properties individually as strings

### DIFF
--- a/src/main/java/com/synopsys/integration/properties/PropertiesManager.java
+++ b/src/main/java/com/synopsys/integration/properties/PropertiesManager.java
@@ -116,7 +116,11 @@ public class PropertiesManager {
 
     protected PropertiesManager(Properties properties) {
         this.properties = new Properties();
-        this.properties.putAll(properties);
+        addProperties(properties);
+    }
+
+    private void addProperties(Properties inputProperties) {
+        inputProperties.forEach((k, v) -> properties.put(k.toString(), v.toString()));
     }
 
     /**


### PR DESCRIPTION
Properties allows adding values of any object type. But, when retrieving the value associated with a key, if the value is not a String, Properties will return a null.

Because of this, when instantiating PropertiesManager from a Properties object via `PropertiesManager.loadProperties`, edit the existing logic to add each key and value as a String.

This edit was tested locally within `blackduck-upload-common`, which is still an internal only library.