### PR TITLE
Add in compatibility to build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,11 @@ buildscript {
 
     apply from: 'https://raw.githubusercontent.com/blackducksoftware/integration-resources/master/gradle_common/buildscript-cgp-version.gradle'
 
+    ext {
+        javaTargetCompatibility = 8
+        javaSourceCompatibility = 8
+    }
+
     dependencies { classpath "com.blackduck.integration:common-gradle-plugin:${managedCgpVersion}" }
 }
 


### PR DESCRIPTION
This is required as downstream libraries require Java 8 .