### PR TITLE
Override equals() of NameVersion object 

### DIFF
--- a/src/main/java/com/blackduck/integration/util/NameVersion.java
+++ b/src/main/java/com/blackduck/integration/util/NameVersion.java
@@ -7,6 +7,9 @@
  */
 package com.blackduck.integration.util;
 
+import java.util.Objects;
+import java.util.Optional;
+
 public class NameVersion extends Stringable {
     private String name;
     private String version;
@@ -15,8 +18,8 @@ public class NameVersion extends Stringable {
     }
 
     public NameVersion(final String name, final String version) {
-        this.name = name;
-        this.version = version;
+        this.name = Optional.ofNullable(name).orElse("");
+        this.version = Optional.ofNullable(version).orElse("");
     }
 
     public NameVersion(final String name) {
@@ -39,4 +42,19 @@ public class NameVersion extends Stringable {
         this.version = version;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        NameVersion that = (NameVersion) o;
+        return Objects.equals(name, that.name) && Objects.equals(version, that.version); // ignore case?
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), name, version);
+    }
 }

--- a/src/main/java/com/blackduck/integration/util/NameVersion.java
+++ b/src/main/java/com/blackduck/integration/util/NameVersion.java
@@ -7,9 +7,6 @@
  */
 package com.blackduck.integration.util;
 
-import java.util.Objects;
-import java.util.Optional;
-
 public class NameVersion extends Stringable {
     private String name;
     private String version;
@@ -18,8 +15,8 @@ public class NameVersion extends Stringable {
     }
 
     public NameVersion(final String name, final String version) {
-        this.name = Optional.ofNullable(name).orElse("");
-        this.version = Optional.ofNullable(version).orElse("");
+        this.name = name;
+        this.version = version;
     }
 
     public NameVersion(final String name) {
@@ -42,19 +39,4 @@ public class NameVersion extends Stringable {
         this.version = version;
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) return false;
-        if (!super.equals(o)) return false;
-        NameVersion that = (NameVersion) o;
-        return Objects.equals(name, that.name) && Objects.equals(version, that.version); // ignore case?
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(super.hashCode(), name, version);
-    }
 }

--- a/src/test/java/com/blackduck/integration/util/NameVersionTest.java
+++ b/src/test/java/com/blackduck/integration/util/NameVersionTest.java
@@ -1,0 +1,31 @@
+package com.blackduck.integration.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+public class NameVersionTest {
+
+    @Test
+    public void testEquals() {
+        NameVersion nameVersion1 = new NameVersion("moduleA", "1.0.0");
+        NameVersion nameVersion2 = new NameVersion("moduleA", "2.0.0");
+
+        assertNotEquals(nameVersion1, nameVersion2);
+    }
+
+    @Test
+    public void testHashCode() {
+        NameVersion nameVersion1 = new NameVersion("moduleA", "1.0.0");
+        NameVersion nameVersion2 = new NameVersion("moduleA", "2.0.0");
+
+        Map<NameVersion, String> map = new HashMap<>();
+        map.putIfAbsent(nameVersion1, "moduleAv1");
+        map.putIfAbsent(nameVersion2, "moduleAv2");
+        assertEquals(map.size(), 2);
+    }
+}


### PR DESCRIPTION
Override equals() of NameVersion object so it can be used to uniquely identify go modules in Detect.