### PR TITLE
Add Alpine linux OS as enum

### DIFF
--- a/src/main/java/com/blackduck/integration/util/OperatingSystemType.java
+++ b/src/main/java/com/blackduck/integration/util/OperatingSystemType.java
@@ -12,7 +12,8 @@ import org.apache.commons.lang3.SystemUtils;
 public enum OperatingSystemType {
     LINUX,
     MAC,
-    WINDOWS;
+    WINDOWS,
+    ALPINE_LINUX;
 
     public static OperatingSystemType determineFromSystem() {
         if (SystemUtils.IS_OS_MAC) {


### PR DESCRIPTION
Add ALPINE_LINUX to support download of alpine linux scan cli beginning 2025.7.0 (This will only be of use if Detect adds a new optional env variable for taking in OS_NAME from customers, this would be helpful since it can be complex to determine alpine from existing Java System Class)

IDETECT-4753